### PR TITLE
update v2.1.7

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v2.1.7 (2023-03-08)
+
+- Added optional parameter (-RunHistoryFile).
+  - Use this parameter to specify a custom path for the history file.
+  - If not used, the default history file path will be used instead.
+
 ## v2.1.6 (2023-02-22)
 
 - Fixed the Teams notification error that happens when the JSON payload shows {} for null in Windows PowerShell. This error does not happen in PowerShell 7.

--- a/source/public/New-MS365IncidentReport.ps1
+++ b/source/public/New-MS365IncidentReport.ps1
@@ -83,7 +83,11 @@ Function New-MS365IncidentReport {
 
         [Parameter()]
         [string[]]
-        $TeamsWebHookURL
+        $TeamsWebHookURL,
+
+        [Parameter()]
+        [string]
+        $RunHistoryFile
     )
 
     if ($StartFromLastRun -and $LastUpdatedTime) {
@@ -115,14 +119,21 @@ Function New-MS365IncidentReport {
 
     #EndRegion
 
-    # Set the run times history file
-    $runHistoryFile = ([System.IO.Path]::Combine($outputDir, "runHistory.csv" ))
+    # Set the run times history file if it isn't specified.
+    if (!($RunHistoryFile)) {
+        $runHistoryFile = ([System.IO.Path]::Combine($outputDir, "runHistory.csv" ))
+    }
+
+    # $runHistoryFile = ([System.IO.Path]::Combine($outputDir, "runHistory.csv" ))
     # Create the history file if it doesn't exist.
     if (!(Test-Path $RunHistoryFile) -or !(Get-Content $RunHistoryFile -Raw -ErrorAction SilentlyContinue)) {
         "RunTime,Status" | Set-Content -Path $RunHistoryFile -Force -Confirm:$false
-        # Add initial entry 'OK' (which means successful) dated 30 days ago. This way there will always be a starting point.
-        "$("{0:yyyy-MM-dd H:mm}" -f $now.AddDays(-30)),OK" | Add-Content -Path $RunHistoryFile -Force -Confirm:$false
+        # Add initial entry 'OK' (which means successful) dated 7 days ago. This way there will always be a starting point.
+        "$("{0:yyyy-MM-dd H:mm}" -f $now.AddDays(-7)),OK" | Add-Content -Path $RunHistoryFile -Force -Confirm:$false
     }
+
+    $RunHistoryFile = (Resolve-Path $RunHistoryFile).Path
+
 
     if (!$OrganizationName) { $OrganizationName = $TenantID }
 


### PR DESCRIPTION
## v2.1.7 (2023-03-08)

- Added optional parameter (`-RunHistoryFile`).
  - Use this parameter to specify a custom path for the history file.
  - If not used, the default history file path will be used instead.